### PR TITLE
Specify character encoding in <meta>

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <link rel="icon" type="image/x-icon" href="img/blueheart.gif">
 
 <!-- Website embed -->
+<meta charset="utf-8"/>
 <meta content="Blueheart" property="og:title"/>
 <meta content="Blueheart - a Tribute" property="og:description"/>
 <meta content="https://blueheart.system64.dev/img/blueheart.gif">


### PR DESCRIPTION
This is required, otherwise browsers have to guess the encoding by the contents for the page with error popping up in console.
>The character encoding of the document was not declared, so the encoding was guessed from content. The character encoding needs to be declared in the Content-Type HTTP header, using a meta tag, or using a byte order mark.